### PR TITLE
Upgrade to latest version of SmartRC-CC1101-Driver-Lib

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,8 +15,8 @@
     }
   ],
   "dependencies": {
-    "name": "RCSwitch-CC1101-Driver-Lib",
-    "version": "https://github.com/LSatan/RCSwitch-CC1101-Driver-Lib.git#2bff72edbee1ee29cbd134d8b2fc47ba0dc0e5f0"
+    "name": "SmartRC-CC1101-Driver-Lib",
+    "version": "https://github.com/LSatan/SmartRC-CC1101-Driver-Lib"
   },
   "version": "1.0.0",
   "frameworks": "arduino",

--- a/src/Somfy_Remote.cpp
+++ b/src/Somfy_Remote.cpp
@@ -140,7 +140,7 @@ void SomfyRemote::sendCommand(uint8_t *frame, uint8_t sync)
     ELECHOUSE_cc1101.setGDO(gdo0Pin, gdo2Pin);
 
     // Initialize radio chip
-    ELECHOUSE_cc1101.Init(PA10);
+    ELECHOUSE_cc1101.Init();
 
     // Enable transmission at 433.42 MHz
     ELECHOUSE_cc1101.SetTx(433.42);

--- a/src/Somfy_Remote.h
+++ b/src/Somfy_Remote.h
@@ -6,7 +6,7 @@ This library is based on the Arduino sketch by Nickduino: https://github.com/Nic
 #define SOMFY_REMOTE
 
 #include <EEPROM.h>
-#include <ELECHOUSE_CC1101_RCS_DRV.h>
+#include <ELECHOUSE_CC1101_SRC_DRV.h>
 
 class SomfyRemote
 {


### PR DESCRIPTION
Make minimum changes required to adopt new version of
https://github.com/LSatan/SmartRC-CC1101-Driver-Lib

- redirect dependency to head of master at LSatan's repo
- reflect changed spelling of library's header file
- remove parameter in call to ELECHOUSE_cc1101.Init()